### PR TITLE
Post Reactions

### DIFF
--- a/src/components/posts/MyPost.css
+++ b/src/components/posts/MyPost.css
@@ -42,3 +42,24 @@
 .postDetailImage {
     align-self: center;
 }
+
+.newReaction-content {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column;
+}
+
+.newReaction-input {
+    margin: 1rem 0;
+}
+
+.newReaction-btns {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+
+}
+
+.reaction-btn {
+    margin: 1rem;
+}

--- a/src/components/posts/PostManager.js
+++ b/src/components/posts/PostManager.js
@@ -90,3 +90,15 @@ export const deletePostReaction = (id) => {
         headers: { "Authorization": `Token ${localStorage.getItem("token")}` }
     })
 }
+
+
+export const addReaction = (reactionBody) => {
+    return fetch("http://localhost:8000/reactions", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Token ${localStorage.getItem("token")}`
+        },
+        body: JSON.stringify(reactionBody)
+    })
+}

--- a/src/components/posts/Postdetail.js
+++ b/src/components/posts/Postdetail.js
@@ -1,48 +1,34 @@
 import React, { useEffect, useState } from "react"
 import { useHistory } from "react-router-dom"
 import { useParams } from "react-router-dom"
-import { getSinglePost, GetPostReactions, New_reaction, deletePostReaction, GetReactions } from "./PostManager"
-import { Message, AddCircleOutline } from '@material-ui/icons';
-import { ListItemIcon, MenuItem, Select } from "@material-ui/core";
+import { getSinglePost, New_reaction, deletePostReaction, GetReactions, deletePost, addReaction } from "./PostManager"
+import { Message } from '@material-ui/icons';
 import TrashIcon from '../comments/trash.svg'
-
-
+import { Button, Dialog, DialogContent, DialogTitle, Input } from "@material-ui/core";
 
 
 export const PostDetail = () => {
     const { postId } = useParams()
-    const [post, setpost] = useState({})
-    const [postReaction, setPostReaction] = useState([])
-    const [reactions, setReaction] = useState(false)
+    const [post, setPost] = useState({})
     const history = useHistory()
-    const [defaultreactions, setreactions] = useState([])
+    const [reactions, setReactions] = useState([])
+    const [reactionCounts, setReactionCounts] = useState([])
+    const [newReaction, setNewReaction] = useState(false)
+    const alertNewReaction = () => setNewReaction(!newReaction)
+    const [newDiag, setNewDiag] = useState(false)
+    const toggleNewDiag = () => setNewDiag(!newDiag)
+    const [newReactionObject, setNewReactionObject] = useState({
+        label: "",
+        image_url: ""
+    })
 
 
     useEffect((
         () => {
-            getSinglePost(parseInt(postId)).then(res => setpost(res))
-            GetReactions().then(res => setreactions(res))
+            getSinglePost(postId).then(setPost)
+            GetReactions().then(setReactions)
         }
-    ), [])
-
-    useEffect((
-        () => {
-            filteredreactions()
-        }
-    ), [])
-
-    useEffect((
-        () => {
-            postReaction.length != 0 ? setReaction(true) : setReaction(false)
-        }
-    ), [postReaction])
-
-    const filteredreactions = () => {
-        return GetPostReactions().then(res => {
-            let array = res.filter(each => each.post_id === parseInt(postId))
-            setPostReaction(array)
-        })
-    }
+    ), [newReaction])
 
     const deletepost = (id) => {
         let result = confirm("Are you sure you want to delete this post? ")
@@ -51,95 +37,118 @@ export const PostDetail = () => {
                 .then(GetPosts)
                 .then(res => setposts(res))
         } else {
-            
+
         }
     }
 
-
-    const addRemoveReaction = (evt) => {
-        evt.preventDefault()
-        const value = evt.target.value
-        if (parseInt(value) === 0) {
-
-        } else {
-            const newPostReaction = {
-                user_id: parseInt(localStorage.getItem('token')),
-                reaction_id: parseInt(value),
-                post_id: parseInt(postId)
-            };
-
-            let reactionPost = postReaction.find((reaction) => {
-                return reaction.user_id === parseInt(localStorage.getItem('token')) && reaction.reaction_id === parseInt(value) && reaction.post_id === parseInt(postId)
+    const handleReaction = (e) => {
+        const reactionExists = post.post_reactions.find(reaction => reaction.user.id === parseInt(localStorage.getItem('userid')) && reaction.post.id === parseInt(postId) && reaction.reaction.id === parseInt(e.target.value))
+        if (reactionExists) {
+            deletePostReaction(reactionExists.id).then(() => {
+                document.getElementById("reactions").value = "0"
+                alertNewReaction()
             })
-
-            reactionPost ? deletePostReaction(reactionPost.id)
-                .then(() => {
-                    filteredreactions().then(document.getElementById("reactions").value = "0")
-                })
-                : New_reaction(newPostReaction)
-                    .then(() => {
-                        filteredreactions()
-                            .then(() => {
-                                countHappy()
-                                countLaugh()
-                                countLove()
-                                countAngry()
-                                countMindBlown()
-                                countSad()
-                            })
-                    })
-                    .then(document.getElementById("reactions").value = "0")
-
+        } else {
+            const newReaction = {
+                post_id: parseInt(postId),
+                reaction_id: parseInt(e.target.value)
+            }
+            New_reaction(newReaction).then(() => {
+                document.getElementById("reactions").value = "0"
+                alertNewReaction()
+            })
         }
     }
 
-    const countReactions = (id) => {
-        const sadEmoji = postReaction.filter((reaction) => {
-            return reaction.reaction_id === parseInt(id)
+    useEffect(() => {
+        if (post.post_reactions) {
+            const updatedReactionCount = []
+            const copy = [...post.post_reactions]
+            for (const reaction of reactions) {
+                const reactionCount = copy.filter(post_reaction => post_reaction.reaction.id === reaction.id)
+                if (reactionCount.length > 0) {
+                    const reactionCountObj = {
+                        reaction: reaction,
+                        count: reactionCount.length
+                    }
+                    updatedReactionCount.push(reactionCountObj)
+                }
+            }
+            updatedReactionCount.sort((a, b) => {
+                return b.count - a.count
+            })
+            setReactionCounts(updatedReactionCount)
+
+        }
+    }, [post.post_reactions, newReaction])
+
+
+    const createNewReactionObject = () => {
+        addReaction(newReactionObject).then(() => {
+            alertNewReaction()
+            toggleNewDiag()
         })
-        return sadEmoji
     }
 
-    return (<>
-        <div key={post.id} className="postDetailContainer">
-            <div className="postDetailTop">
-                <div><button className="postDetailAddComments" onClick={() => history.push(`/commentForm/${post.id}`)}><Message /></button></div>
-                <div className="postDetailTitle"> {post.title}</div>
-                <div className="postDetailCategory">{post.category?.label}</div>
-            </div>
-            <div className="postdetailbottom"> publication date: {post.publication_date}</div>
-            <div className="postDetailImage"><img src={post.image_url}></img></div>
-            <div className="postDetailBottom">
-                <div className="postDetailName">By {post.user?.first_name} {post.user?.last_name}</div>
-                <button className="postDetailViewComments" onClick={() => { history.push(`/comments/${post.id}`) }}>View Comments</button>
-                <div className="postAddReaction">
-                    <select className="emojiselect" defaultValue="0" onChange={(evt) => { addRemoveReaction(evt) }} name="reactions" id="reactions">
-                        <option className="emojiOption" value="0">+</option>
-                        {defaultreactions.map(each => {
-                            return <option key={each.id} className="emojiOption" value={each.id}>{each.image_url} </option>
-                        })}
-                    </select>
+    return (
+        <>
+            <div key={post.id} className="postDetailContainer">
+                <div className="postDetailTop">
+                    <div><button className="postDetailAddComments" onClick={() => history.push(`/commentForm/${post.id}`)}><Message /></button></div>
+                    <div className="postDetailTitle"> {post.title}</div>
+                    <div className="postDetailCategory">{post.category?.label}</div>
+                </div>
+                <div className="postdetailbottom"> publication date: {post.publication_date}</div>
+                <div className="postDetailImage"><img src={post.image_url}></img></div>
+                <div className="postDetailBottom">
+                    <div className="postDetailName">By {post.user?.user?.first_name} {post.user?.user?.last_name}</div>
+                    <button className="postDetailViewComments" onClick={() => { history.push(`/comments/${post.id}`) }}>View Comments</button>
 
-                    <div className="postReactions">
-                        {
-                            defaultreactions.map(
-                                eachReaction => {
-                                    return countReactions(eachReaction.id).length >= 1
-                                        ? <div key={eachReaction.id} className="reactionContainer">
-                                            <div className="emoji">{eachReaction.image_url}</div>
-                                            <div className={countReactions(eachReaction.id).length > 1 ? "reactionNumber" : "reactionNumber invisible"}>
-                                                {countReactions(eachReaction.id).length}
-                                            </div>
-                                        </div>
-                                        : ""
-                                }
-                            )
-                        }
+                    <div><button onClick={toggleNewDiag}>New Reaction</button></div>
+                    <Dialog open={newDiag} onClose={toggleNewDiag}>
+                        <DialogTitle className="newReaction-title">Create New Reaction Option</DialogTitle>
+                        <DialogContent className="newReaction-content">
+                            <Input className="newReaction-input" id="newReaction-label" placeholder="Label" onChange={(e) => {
+                                const copy = { ...newReactionObject }
+                                copy.label = e.target.value
+                                setNewReactionObject(copy)
+                            }}></Input>
+                            <Input className="newReaction-input" id="newReaction-imageUrl" placeholder="Emoji" onChange={(e) => {
+                                const copy = { ...newReactionObject }
+                                copy.image_url = e.target.value
+                                setNewReactionObject(copy)
+                            }}></Input>
+                        </DialogContent>
+                        <div className="newReaction-btns">
+                            <div className="reaction-btn"><Button className="reaction-btn" variant="outlined" onClick={createNewReactionObject}>Save</Button></div>
+                            <div className="reaction-btn"><Button className="reaction-btn" variant="outlined" onClick={toggleNewDiag}>Cancel</Button></div>
+                        </div>
+
+                    </Dialog>
+
+                    <div className="postAddReaction">
+                        <select className="emojiselect" defaultValue="0" onChange={handleReaction} name="reactions" id="reactions">
+                            <option key={"0"} className="emojiOption" value="0">+</option>
+                            {reactions.map(each => {
+                                return <option key={each.id} className="emojiOption" value={each.id}>{each.image_url} </option>
+                            })}
+                        </select>
+
+                        <div className="postReactions">
+                            {
+                                reactionCounts.map((reactionCount) => {
+                                    return <div key={reactionCount.id}>
+                                        <div>{reactionCount.reaction.image_url}</div>
+                                        <div className={reactionCount.count > 1 ? "reactionNumber" : "reactionNumber invisible"}>{reactionCount.count}</div>
+                                    </div>
+                                })
+                            }
+                        </div>
                     </div>
                 </div>
+                <div className="postDetailContent">{post.content}</div>
             </div>
-            <div className="postDetailContent">{post.content}</div>
-        </div>
-        <button onClick={() => deletepost(post.id)}><img src={TrashIcon} style={{ height: "1.25rem" }} ></img></button>              
-    </>)
+            <button onClick={() => deletepost(post.id)}><img src={TrashIcon} style={{ height: "1.25rem" }} ></img></button>
+        </>
+    )
 }


### PR DESCRIPTION
User can add and delete reactions to a post using the dropdown. For two or more reactions a number will appear under the emoji.
Users (eventually only admin) can create a new reaction to use in the drop down using the "new reaction" button and form.

To Test in Browser:
- Provided that the user is logged in as an authorized user and viewing the Post Details page of a single post, any existing post_reaction emojis should appear under the post image.
- Using the select dropdown, a user can add and delete reactions to the post, appropriately incrementing the count on the relevant reaction.
- Clicking on the "Add reaction" button will prompt a dialog box to appear where the user can submit a new reaction (providing the label and the emoji) and, when saved, that reaction will immediately appear in the reaction dropdown list.