### PR TITLE
Activate and Deactivate Users

### DIFF
--- a/src/components/Users/Users.js
+++ b/src/components/Users/Users.js
@@ -15,6 +15,9 @@ export const Users = () => {
     const alertNewState = () => setNewState(!newState)
     const [warningDiag, setWarningDiag] = useState(false)
     const toggleWarningDiag = () => setWarningDiag(!warningDiag)
+    const [confirmDiag, setConfirmDiag] = useState(false)
+    const toggleConfirm = () => setConfirmDiag(!confirmDiag)
+    const [user, setUser] = useState({})
 
     // Use Effects
     //-------------------------------------------------------------------------------------------------------------------
@@ -36,7 +39,8 @@ export const Users = () => {
             if (user.id === userId) {
                 toggleWarningDiag()
             } else {
-                deactivateUser(user.id).then(alertNewState)
+                setUser(user)
+                toggleConfirm()
             }
         }
         else {
@@ -52,9 +56,9 @@ export const Users = () => {
                     <h1 className="userListHead">Active Users</h1>
                     {activeUsers.map((user) => {
                         return <div key={user.id} className="user">
-                            <p>UserName: <Link to={`/users/${user.id}`}>{user.user.username}</Link></p>
+                            <p>Display Name: <Link to={`/users/${user.id}`}>{user.user.username}</Link></p>
                             <p>Full Name: {user.user.first_name} {user.user.last_name} </p>
-                            <p>Email: {user.user.email}</p>
+                            <p>User Type: {user.user.is_staff ? 'Admin' : 'Author'}</p>
                             <button onClick={() => changeActiveState(user)}>Deactivate</button>
                         </div>
                     })}
@@ -64,9 +68,9 @@ export const Users = () => {
                     <h1 className="userListHead">Deactivated Users</h1>
                     {inactiveUsers.map((user) => {
                         return <div key={user.id} className="user">
-                            <p>UserName: <Link to={`/users/${user.id}`}>{user.user.username}</Link></p>
+                            <p>Display Name: <Link to={`/users/${user.id}`}>{user.user.username}</Link></p>
                             <p>Full Name: {user.user.first_name} {user.user.last_name} </p>
-                            <p>Email: {user.user.email}</p>
+                            <p>User Type: {user.user.is_staff ? 'Admin' : 'Author'}</p>
                             <button onClick={() => changeActiveState(user)}>Reactivate</button>
                         </div>
                     })}
@@ -76,24 +80,24 @@ export const Users = () => {
             </div>
 
             <Dialog open={warningDiag} onClose={toggleWarningDiag}>
-                    <DialogTitle className="newReaction-title">Don't Deactivate Yourself!</DialogTitle>
-                    <DialogContent className="newReaction-content">
-                        {/* <Input className="newReaction-input" id="newReaction-label" placeholder="Label" onChange={(e) => {
-                            const copy = { ...newReactionObject }
-                            copy.label = e.target.value
-                            setNewReactionObject(copy)
-                        }}></Input>
-                        <Input className="newReaction-input" id="newReaction-imageUrl" placeholder="Emoji" onChange={(e) => {
-                            const copy = { ...newReactionObject }
-                            copy.image_url = e.target.value
-                            setNewReactionObject(copy)
-                        }}></Input> */}
-                    </DialogContent>
-                    <div className="newReaction-btns">
-                        <div className="reaction-btn"><Button className="reaction-btn" variant="outlined" onClick={toggleWarningDiag}>Ok</Button></div>
-                    </div>
+                <DialogTitle className="newReaction-title">Don't Deactivate Yourself!</DialogTitle>
+                <div className="newReaction-btns">
+                    <div className="reaction-btn"><Button className="reaction-btn" variant="outlined" onClick={toggleWarningDiag}>Ok</Button></div>
+                </div>
+            </Dialog>
 
-                </Dialog>
+            <Dialog open={confirmDiag} onClose={toggleConfirm}>
+                <DialogTitle className="newReaction-title">Are You Sure You Want to Deactivate This User?</DialogTitle>
+                <div className="newReaction-btns">
+                    <div className="reaction-btn"><Button className="reaction-btn" variant="outlined" 
+                    onClick={() => {
+                        deactivateUser(user.id).then(alertNewState)
+                        toggleConfirm()
+                    }}>Deactivate</Button></div>
+                    <div className="reaction-btn"><Button className="reaction-btn" variant="outlined" onClick={toggleConfirm}>Cancel</Button></div>
+
+                </div>
+            </Dialog>
 
         </>
     )

--- a/src/components/Users/Users.js
+++ b/src/components/Users/Users.js
@@ -1,40 +1,103 @@
 import React, { useEffect, useState } from "react"
-import { useParams, useHistory, Link, useLocation} from "react-router-dom"
-import {getAllUsers} from './userManager'
+import { useParams, useHistory, Link, useLocation } from "react-router-dom"
+import { getAllUsers, activateUser, deactivateUser } from './userManager'
+import { Button, Dialog, DialogContent, DialogTitle, Input } from "@material-ui/core";
 import "./user.css"
 
 
 export const Users = () => {
-    
-        // Use States
-        //-------------------------------------------------------------------------------------------------------------------
-        const [users, setUsers] = useState([])
-    
-        // Use Effects
-        //-------------------------------------------------------------------------------------------------------------------
-    
-        useEffect(
-            () => {
-                getAllUsers()
-                    .then((data) => {
-                        setUsers(data)
-                    })
-            },
-            []
-        )
+    // Use States
+    //-------------------------------------------------------------------------------------------------------------------
+    const [activeUsers, setActiveUsers] = useState([])
+    const [inactiveUsers, setInactiveUsers] = useState([])
+    const userId = parseInt(localStorage.getItem('userid'))
+    const [newState, setNewState] = useState(false)
+    const alertNewState = () => setNewState(!newState)
+    const [warningDiag, setWarningDiag] = useState(false)
+    const toggleWarningDiag = () => setWarningDiag(!warningDiag)
 
-        return (
-            <>
+    // Use Effects
+    //-------------------------------------------------------------------------------------------------------------------
+    useEffect(
+        () => {
+            getAllUsers()
+                .then((data) => {
+                    const active = data.filter(user => user.user.is_active === true)
+                    const inactive = data.filter(user => user.user.is_active !== true)
+                    setActiveUsers(active)
+                    setInactiveUsers(inactive)
+                })
+        },
+        [newState]
+    )
+
+    const changeActiveState = (user) => {
+        if (user.user.is_active) {
+            if (user.id === userId) {
+                toggleWarningDiag()
+            } else {
+                deactivateUser(user.id).then(alertNewState)
+            }
+        }
+        else {
+            activateUser(user.id).then(alertNewState)
+        }
+    }
+
+    return (
+        <>
             <div className="userBlock">
-            <h1 className="userListHead">Users</h1>
-               { users.map((user) => {
-                   return <div className="user">
+
+                <div className="activeUsers">
+                    <h1 className="userListHead">Active Users</h1>
+                    {activeUsers.map((user) => {
+                        return <div key={user.id} className="user">
                             <p>UserName: <Link to={`/users/${user.id}`}>{user.user.username}</Link></p>
                             <p>Full Name: {user.user.first_name} {user.user.last_name} </p>
                             <p>Email: {user.user.email}</p>
+                            <button onClick={() => changeActiveState(user)}>Deactivate</button>
                         </div>
-                }) }
+                    })}
                 </div>
-            </>
-        )
+
+                <div className="deactivatedUsers">
+                    <h1 className="userListHead">Deactivated Users</h1>
+                    {inactiveUsers.map((user) => {
+                        return <div key={user.id} className="user">
+                            <p>UserName: <Link to={`/users/${user.id}`}>{user.user.username}</Link></p>
+                            <p>Full Name: {user.user.first_name} {user.user.last_name} </p>
+                            <p>Email: {user.user.email}</p>
+                            <button onClick={() => changeActiveState(user)}>Reactivate</button>
+                        </div>
+                    })}
+
+                </div>
+
+            </div>
+
+            <Dialog open={warningDiag} onClose={toggleWarningDiag}>
+                    <DialogTitle className="newReaction-title">Don't Deactivate Yourself!</DialogTitle>
+                    <DialogContent className="newReaction-content">
+                        {/* <Input className="newReaction-input" id="newReaction-label" placeholder="Label" onChange={(e) => {
+                            const copy = { ...newReactionObject }
+                            copy.label = e.target.value
+                            setNewReactionObject(copy)
+                        }}></Input>
+                        <Input className="newReaction-input" id="newReaction-imageUrl" placeholder="Emoji" onChange={(e) => {
+                            const copy = { ...newReactionObject }
+                            copy.image_url = e.target.value
+                            setNewReactionObject(copy)
+                        }}></Input> */}
+                    </DialogContent>
+                    <div className="newReaction-btns">
+                        <div className="reaction-btn"><Button className="reaction-btn" variant="outlined" onClick={toggleWarningDiag}>Ok</Button></div>
+                    </div>
+
+                </Dialog>
+
+        </>
+    )
 }
+
+
+

--- a/src/components/Users/userManager.js
+++ b/src/components/Users/userManager.js
@@ -11,3 +11,17 @@ export const getSingleUser = (id) => {
     })
     .then(res => res.json())
 }
+
+export const activateUser = (id) => {
+    return fetch(`http://localhost:8000/users/${id}/activate`, {
+        method: "PUT",
+        headers: { "Authorization": `Token ${localStorage.getItem("token")}` }
+    })
+}
+
+export const deactivateUser = (id) => {
+    return fetch(`http://localhost:8000/users/${id}/deactivate`, {
+        method: "PUT",
+        headers: { "Authorization": `Token ${localStorage.getItem("token")}` }
+    })
+}


### PR DESCRIPTION
On the User Management Page, users are now filtered into two lists: active and deactivated. The user can deactivate and reactivate users directly from the page view using buttons on each user card.

To Test:
**A user is unable to deactivate themselves so you need to have at least two registered users in the database to test properly.
- When the user clicks on the "Deactivate" button on a user card, they will be prompted to confirm with a dialog box. Upon confirmation, the user will immediately have their 'is_active' property altered and the user lists will re-render.
- When the user clicks on the "Reactivate" button on a user card, the targeted user be updated and the lists will refresh.
- If the user attempts to deactivate their own account, a dialog box will appear alerting them that they can't do that.

*Currently the ability to change user status is not limited to admin privileges, but that will be added in later features.