### PR TITLE
User Type Management

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -16,6 +16,7 @@ import { Landing } from "./home/Landing"
 import { AdminPostList } from "./posts/adminPostList" 
 
 export const ApplicationViews = () => {
+  const admin = localStorage.getItem('isStaff') === "true"
   return (<>
 
     <Route exact path="/posts" >
@@ -43,8 +44,13 @@ export const ApplicationViews = () => {
       <NewPost/>
     </Route>          
     <Route exact path="/users">
-        <Users />
-      </Route>
+      {
+        admin
+        ? <Users /> 
+        : ""
+      }
+       
+    </Route>
     <Route exact path="/users/:userId">
         <UserPage />
     </Route>

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -49,7 +49,7 @@ export const ApplicationViews = () => {
         ? <Users /> 
         : ""
       }
-       
+
     </Route>
     <Route exact path="/users/:userId">
         <UserPage />

--- a/src/components/Users/Users.js
+++ b/src/components/Users/Users.js
@@ -38,7 +38,7 @@ export const Users = () => {
 
 
     const changeActiveState = (user) => {
-        const currentDemotion = user.demotions.find(demotion => demotion.deactivate === true)
+        const currentDemotion = user.demotions?.find(demotion => demotion.deactivate === true)
         if (user.user.is_active) {
             if (user.id === userId) {
                 toggleWarningDiag()
@@ -65,7 +65,7 @@ export const Users = () => {
     }
 
     const changeAdminState = (user) => {
-        const currentDemotion = user.demotions.find(demotion => demotion.demote === true)
+        const currentDemotion = user.demotions?.find(demotion => demotion.demote === true)
         if (user.user.is_staff) {
             if (currentDemotion && currentDemotion.first_approver.id === parseInt(localStorage.getItem('userid'))) {
                 deleteDemotion(currentDemotion.id).then(alertNewState)
@@ -74,7 +74,7 @@ export const Users = () => {
                 const admins = activeUsers.filter(user => user.user.is_staff)
                 admins.length > 1
                     ? removeAdmin(user.id).then(() => {
-                        const adminDemotions = user.demotions.filter(demotion => demotion.demote === true)
+                        const adminDemotions = user.demotions?.filter(demotion => demotion.demote === true)
                         for (const demotion of adminDemotions) {
                             deleteDemotion(demotion.id)
                         }
@@ -137,7 +137,7 @@ export const Users = () => {
                             <button onClick={() => changeAdminState(user)}>
                                 {
                                     user.user.is_staff
-                                        ? user.demotions.find(demotion => demotion.demote === true)
+                                        ? user.demotions?.find(demotion => demotion.demote === true)
                                             ? user.demotions?.find(demotion => demotion.demote === true && demotion.first_approver.id === parseInt(localStorage.getItem('userid')))
                                                 ? "Remove Recommendation to Demote"
                                                 : "Demote"

--- a/src/components/Users/Users.js
+++ b/src/components/Users/Users.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react"
 import { useParams, useHistory, Link, useLocation } from "react-router-dom"
-import { getAllUsers, activateUser, deactivateUser } from './userManager'
+import { getAllUsers, activateUser, deactivateUser, removeAdmin, makeAdmin, addDemotion, deleteDemotion } from './userManager'
 import { Button, Dialog, DialogContent, DialogTitle, Input } from "@material-ui/core";
 import "./user.css"
 
@@ -18,6 +18,8 @@ export const Users = () => {
     const [confirmDiag, setConfirmDiag] = useState(false)
     const toggleConfirm = () => setConfirmDiag(!confirmDiag)
     const [user, setUser] = useState({})
+    const [adminDiag, setAdminDiag] = useState(false)
+    const toggleAdminDiag = () => setAdminDiag(!adminDiag)
 
     // Use Effects
     //-------------------------------------------------------------------------------------------------------------------
@@ -34,17 +36,65 @@ export const Users = () => {
         [newState]
     )
 
+
     const changeActiveState = (user) => {
+        const currentDemotion = user.demotions.find(demotion => demotion.deactivate === true)
         if (user.user.is_active) {
             if (user.id === userId) {
                 toggleWarningDiag()
-            } else {
+            } else if (currentDemotion && currentDemotion.first_approver.id === parseInt(localStorage.getItem('userid'))) {
+                deleteDemotion(currentDemotion.id).then(alertNewState)
+            } else if (currentDemotion) {
                 setUser(user)
                 toggleConfirm()
+            } else {
+                const newDemotion = {
+                    userId: user.id,
+                    deactivate: true,
+                    demote: false
+                }
+                addDemotion(newDemotion).then(alertNewState)
             }
         }
         else {
+            for (const demotion of user.demotions) {
+                deleteDemotion(demotion.id)
+            }
             activateUser(user.id).then(alertNewState)
+        }
+    }
+
+    const changeAdminState = (user) => {
+        const currentDemotion = user.demotions.find(demotion => demotion.demote === true)
+        if (user.user.is_staff) {
+            if (currentDemotion && currentDemotion.first_approver.id === parseInt(localStorage.getItem('userid'))) {
+                deleteDemotion(currentDemotion.id).then(alertNewState)
+            } else if (currentDemotion) {
+                // check if there is at least one user with is_staff true
+                const admins = activeUsers.filter(user => user.user.is_staff)
+                admins.length > 1
+                    ? removeAdmin(user.id).then(() => {
+                        const adminDemotions = user.demotions.filter(demotion => demotion.demote === true)
+                        for (const demotion of adminDemotions) {
+                            deleteDemotion(demotion.id)
+                        }
+                        alertNewState()
+                    })
+                    : toggleAdminDiag()
+
+            } else {
+                const newDemotion = {
+                    userId: user.id,
+                    deactivate: false,
+                    demote: true
+                }
+                addDemotion(newDemotion).then(alertNewState)
+            }
+        } else {
+            for (const demotion of user.demotions) {
+                deleteDemotion(demotion.id)
+            }
+            makeAdmin(user.id).then(alertNewState)
         }
     }
 
@@ -59,7 +109,43 @@ export const Users = () => {
                             <p>Display Name: <Link to={`/users/${user.id}`}>{user.user.username}</Link></p>
                             <p>Full Name: {user.user.first_name} {user.user.last_name} </p>
                             <p>User Type: {user.user.is_staff ? 'Admin' : 'Author'}</p>
-                            <button onClick={() => changeActiveState(user)}>Deactivate</button>
+                            {
+                                user.demotions?.find(demotion => demotion.deactivate === true)
+                                    ? <div className="recommendDeactivate">Recommended for Deactivation</div>
+                                    : ""
+                            }
+                            {
+                                user.demotions?.find(demotion => demotion.demote === true)
+                                    ? <div className="recommendDemote">Recommended for Demotion to Author</div>
+                                    : ""
+                            }
+
+
+
+                            <button onClick={() => changeActiveState(user)}>
+                                {
+                                    user.demotions?.find(demotion => demotion.deactivate === true)
+                                        ? user.demotions?.find(demotion => demotion.deactivate === true && demotion.first_approver.id === parseInt(localStorage.getItem('userid')))
+                                            ? "Remove Recommendation to Deactivate"
+                                            : "Deactivate"
+                                        : "Recommend Deactivate"
+                                }
+                            </button>
+                            {
+
+                            }
+                            <button onClick={() => changeAdminState(user)}>
+                                {
+                                    user.user.is_staff
+                                        ? user.demotions.find(demotion => demotion.demote === true)
+                                            ? user.demotions?.find(demotion => demotion.demote === true && demotion.first_approver.id === parseInt(localStorage.getItem('userid')))
+                                                ? "Remove Recommendation to Demote"
+                                                : "Demote"
+                                            : "Recommend Demotion"
+                                        : "Make Admin"
+                                }
+                            </button>
+
                         </div>
                     })}
                 </div>
@@ -86,14 +172,22 @@ export const Users = () => {
                 </div>
             </Dialog>
 
+            <Dialog open={adminDiag} onClose={toggleAdminDiag}>
+                <DialogTitle className="newReaction-title">There needs to be at least one active admin.</DialogTitle>
+                <DialogContent>Please make another user an admin before demoting this user.</DialogContent>
+                <div className="newReaction-btns">
+                    <div className="reaction-btn"><Button className="reaction-btn" variant="outlined" onClick={toggleAdminDiag}>Ok</Button></div>
+                </div>
+            </Dialog>
+
             <Dialog open={confirmDiag} onClose={toggleConfirm}>
                 <DialogTitle className="newReaction-title">Are You Sure You Want to Deactivate This User?</DialogTitle>
                 <div className="newReaction-btns">
-                    <div className="reaction-btn"><Button className="reaction-btn" variant="outlined" 
-                    onClick={() => {
-                        deactivateUser(user.id).then(alertNewState)
-                        toggleConfirm()
-                    }}>Deactivate</Button></div>
+                    <div className="reaction-btn"><Button className="reaction-btn" variant="outlined"
+                        onClick={() => {
+                            deactivateUser(user.id).then(alertNewState)
+                            toggleConfirm()
+                        }}>Deactivate</Button></div>
                     <div className="reaction-btn"><Button className="reaction-btn" variant="outlined" onClick={toggleConfirm}>Cancel</Button></div>
 
                 </div>

--- a/src/components/Users/user.css
+++ b/src/components/Users/user.css
@@ -39,3 +39,11 @@
     display: flex;
     margin-right: 5px;
 }
+
+.recommendDeactivate {
+    color: red;
+}
+
+.recommendDemote {
+    color: orange;
+}

--- a/src/components/Users/userManager.js
+++ b/src/components/Users/userManager.js
@@ -25,3 +25,37 @@ export const deactivateUser = (id) => {
         headers: { "Authorization": `Token ${localStorage.getItem("token")}` }
     })
 }
+
+export const makeAdmin = (id) => {
+    return fetch(`http://localhost:8000/users/${id}/makeadmin`, {
+        method: "PUT",
+        headers: { "Authorization": `Token ${localStorage.getItem("token")}` }
+    })
+}
+
+export const removeAdmin = (id) => {
+    return fetch(`http://localhost:8000/users/${id}/removeadmin`, {
+        method: "PUT",
+        headers: { "Authorization": `Token ${localStorage.getItem("token")}` }
+    })
+}
+
+export const addDemotion = (new_demotion) => {
+    return fetch("http://localhost:8000/demotions", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Token ${localStorage.getItem('token')}`
+        },
+        body: JSON.stringify(new_demotion)
+    })
+}
+
+export const deleteDemotion = (demotionId) => {
+    return fetch(`http://localhost:8000/demotions/${demotionId}`, {
+        method: "DELETE",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem('token')}`
+        }
+      })
+}

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -7,6 +7,7 @@ export const NavBar = ({ token, setToken }) => {
   const history = useHistory()
   const navbar = useRef()
   const hamburger = useRef()
+  const admin = localStorage.getItem('isStaff') === "true"
 
   const showMobileNavbar = () => {
     hamburger.current.classList.toggle('is-active')
@@ -36,7 +37,12 @@ export const NavBar = ({ token, setToken }) => {
               <Link to="/posts" className="navbar-item">Posts</Link>
               <Link to="/adminposts" className="navbar-item">AdminPosts</Link>
               <Link to="/categories" className="navbar-item">Category Manager</Link>
-              <Link to="/users" className="navbar-item">User Management</Link>
+              {
+                admin
+                ? <Link to="/users" className="navbar-item">User Management</Link>
+                : ""
+              }
+              
               <Link to="/tags" className="navbar-item">Tag Management</Link>
               <Link to="/my-posts" className="navbar-item">My Posts</Link>
               <Link to="/new-post" className="navbar-item">New Post</Link>

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -60,6 +60,7 @@ export const NavBar = ({ token, setToken }) => {
                   ?
                   <button className="button is-outlined" onClick={() => {
                     setToken('')
+                    localStorage.removeItem('isStaff')
                     history.push('/login')
                   }}>Logout</button>
                   :


### PR DESCRIPTION
Lots of conditional styling and functionality for buttons:

- Only admin users can access the User Management page (conditional logic in nav bar and application views)
- If a user is in good standing, an admin can recommend them to be deactivated. That same admin can remove a recommendation to deactivate. An additional admin is required to made a deactivation request before that user is deactivated.
- Once deactivated, the user will lose all application access and their user card will appear in the "Deactivated Users" list, with the option for an admin to reactivate them if necessary.
- Admins can also make regular users admins and recommend/fully demote current admins to regular user status.
- An admin cannot demote the last admin without promoting another user to admin status