### PR TITLE
fixed rerender issue with editing category

### DIFF
--- a/src/components/categories/EditCategory.js
+++ b/src/components/categories/EditCategory.js
@@ -25,7 +25,7 @@ export const EditCategory = () => {
                 "Content-Type": "application/json",
                 "Authorization": `Token ${localStorage.getItem("token")}`
             },
-        body: JSON.stringify(editedCat)}).then(history.push('/categories'))
+        body: JSON.stringify(editedCat)}).then( () => {history.push('/categories')})
 
 
     }


### PR DESCRIPTION
dom rerenders every time now, to test try editing a category numerous times, also change the length of the category name when typing in input, i've noticed it can make it more liable to break if you go from a one word to multiple sentences.